### PR TITLE
ci: upgrade Node.js 20 → 22 and opt into Actions Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,10 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
       - run: npm ci
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # ── deps: install with native build tools ────────────────────────────────────
-FROM node:20-alpine AS deps
+FROM node:22-alpine AS deps
 RUN apk add --no-cache python3 make g++
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 
 # ── builder: compile app + standalone output ──────────────────────────────────
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 RUN apk add --no-cache python3 make g++
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
@@ -14,7 +14,7 @@ COPY . .
 RUN npm run build
 
 # ── runner: only the standalone bundle (no src, no node_modules, no build tools)
-FROM node:20-alpine AS runner
+FROM node:22-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 ENV DATABASE_PATH=/app/data/geocode.db


### PR DESCRIPTION
## Summary

- Bumps `node-version` from 20 to 22 LTS in CI (Node 20 reached EOL 2026-04-30)
- Updates all three Dockerfile stages from `node:20-alpine` to `node:22-alpine`
- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to silence the `actions/checkout` and `actions/setup-node` deprecation warning before the forced cutover on 2026-06-02

## Test plan

- [ ] CI passes on this branch with Node 22
- [ ] No regressions in typecheck / lint / format / test / build steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)