### PR TITLE
fix: allow geolocation for same-origin in Permissions-Policy

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -28,7 +28,7 @@ const nextConfig: NextConfig = {
           { key: "Content-Security-Policy", value: csp },
           {
             key: "Permissions-Policy",
-            value: "geolocation=(), camera=(), microphone=(), payment=()",
+            value: "geolocation=(self), camera=(), microphone=(), payment=()",
           },
         ],
       },


### PR DESCRIPTION
## Summary

- Changes `geolocation=()` → `geolocation=(self)` in the `Permissions-Policy` response header
- `geolocation=()` was blocking `navigator.geolocation` entirely, so the locate-me button on the map always failed silently
- Third-party frames (iframes) still cannot request geolocation

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)