### PR TITLE
fix: allow filter panel to scroll to bottom on mobile

### DIFF
--- a/components/MapPage.tsx
+++ b/components/MapPage.tsx
@@ -647,7 +647,7 @@ export default function MapPage() {
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
             </svg>
           </button>
-          {filterPanel}
+          <div className="flex-1 min-h-0">{filterPanel}</div>
           <div
             className="shrink-0 px-4 py-3 border-t border-gray-100 bg-white"
             style={{ paddingBottom: "max(12px, env(safe-area-inset-bottom))" }}


### PR DESCRIPTION
## Summary

- Wraps `{filterPanel}` in `<div className="flex-1 min-h-0">` inside the mobile filter overlay
- Without this, the panel was a bare `h-full` flex child that grew past the sticky apply button; `overflow-hidden` on the outer shell clipped the bottom of the filter list
- The apply button now stays pinned at the bottom and the filter list scrolls independently above it

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)