### PR TITLE
docs: remove NOMINATIM_DISABLED from README env vars table

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,9 @@ Requires Node.js 20+. No `.env` file needed — defaults work out of the box.
 
 **Optional environment variables:**
 
-| Variable             | Default             | Description                                                                |
-| -------------------- | ------------------- | -------------------------------------------------------------------------- |
-| `DATABASE_PATH`      | `./data/geocode.db` | SQLite database location                                                   |
-| `NOMINATIM_DISABLED` | `false`             | Set to `true` to disable the Nominatim geocoding fallback (swisstopo only) |
+| Variable        | Default             | Description              |
+| --------------- | ------------------- | ------------------------ |
+| `DATABASE_PATH` | `./data/geocode.db` | SQLite database location |
 
 ---
 


### PR DESCRIPTION
## Summary

- Removes the `NOMINATIM_DISABLED` row from the optional environment variables table — it was re-introduced by #15 which branched before the Nominatim removal in #14 landed
- No code changes, README only

🤖 Generated with [Claude Code](https://claude.com/claude-code)