### PR TITLE
ci: upgrade actions/checkout to v5, move Node24 flag to job level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,15 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
       - run: npm ci
 
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 


### PR DESCRIPTION
## Summary

- Upgrades `actions/checkout@v4` → `v5` in both the `ci` and `deploy` jobs — v4 runs on Node.js 20 which is deprecated on GitHub Actions (forced cutover June 2nd, 2026)
- Moves `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` from the `setup-node` step to the job-level `env` block so it covers all steps including `checkout`

🤖 Generated with [Claude Code](https://claude.com/claude-code)