### PR TITLE
feat: stale-while-revalidate for seeded course cache

### DIFF
--- a/__tests__/staleSeedCache.test.ts
+++ b/__tests__/staleSeedCache.test.ts
@@ -349,6 +349,44 @@ describe("stale-while-revalidate seed cache", () => {
 
     expect(mockOrphanedImagesDeleteRun).toHaveBeenCalled();
   });
+
+  it("aborts snapshot replacement when one kurstyp returns an empty-but-successful response", async () => {
+    const course = makeMinimalCourse();
+    mockFetchedAtGet.mockReturnValue({ max_fetched_at: daysAgo(10) }); // stale
+    mockSeededCoursesAll.mockReturnValue([seededRow(course)]);
+
+    // Resolve when background refresh logs the per-type abort warning
+    let resolveAborted!: () => void;
+    const aborted = new Promise<void>((resolve) => {
+      resolveAborted = resolve;
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation((...args) => {
+      if (String(args[0]).includes("aborting")) resolveAborted();
+    });
+
+    // First POST (kurstyp 1 first page) returns 0 courses — simulates transient empty response
+    let postCallCount = 0;
+    mockFetch.mockImplementation((_url: unknown, init?: { method?: string }) => {
+      if (init?.method === "POST") {
+        postCallCount++;
+        return Promise.resolve(
+          postCallCount === 1
+            ? mockCoursePage([], 0) // kurstyp 1 → empty
+            : mockCoursePage([makeMinimalCourse({ angebotId: 99 })])
+        );
+      }
+      return Promise.resolve(mockTokenResponse());
+    });
+
+    try {
+      await fetchAllCourses({ kurstyp: 2 }); // returns stale, triggers background refresh
+      await aborted; // wait until the abort warning fires
+
+      expect(mockDeleteRun).not.toHaveBeenCalled(); // transaction was not reached
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 });
 
 describe("seeded lookup cache", () => {

--- a/__tests__/staleSeedCache.test.ts
+++ b/__tests__/staleSeedCache.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // ── DB mock ───────────────────────────────────────────────────────────────────
-const { mockFetchedAtGet, mockSeededCoursesAll, mockInsertRun, mockTransaction } = vi.hoisted(
-  () => ({
+const { mockFetchedAtGet, mockSeededCoursesAll, mockInsertRun, mockDeleteRun, mockTransaction } =
+  vi.hoisted(() => ({
     mockFetchedAtGet: vi.fn(),
     mockSeededCoursesAll: vi.fn(),
     mockInsertRun: vi.fn(),
+    mockDeleteRun: vi.fn(),
     mockTransaction: vi.fn((fn: () => void) => fn),
-  })
-);
+  }));
 
 vi.mock("@/lib/db", () => ({
   default: {
@@ -17,7 +17,8 @@ vi.mock("@/lib/db", () => ({
       if (sql.includes("SELECT data") && sql.includes("kurstypId"))
         return { all: mockSeededCoursesAll };
       if (sql.includes("INSERT")) return { run: mockInsertRun };
-      return { get: vi.fn().mockReturnValue(null), all: vi.fn().mockReturnValue([]) };
+      if (sql.includes("DELETE FROM courses")) return { run: mockDeleteRun };
+      return { get: vi.fn().mockReturnValue(null), all: vi.fn().mockReturnValue([]), run: vi.fn() };
     }),
     transaction: mockTransaction,
   },
@@ -110,6 +111,7 @@ describe("stale-while-revalidate seed cache", () => {
     mockFetchedAtGet.mockReset();
     mockSeededCoursesAll.mockReset();
     mockInsertRun.mockReset();
+    mockDeleteRun.mockReset();
     mockFetch.mockReset();
     // Vitest sets NODE_ENV=test which disables the seeded cache; override for these tests.
     vi.stubEnv("NODE_ENV", "production");
@@ -200,9 +202,11 @@ describe("stale-while-revalidate seed cache", () => {
     mockFetchedAtGet.mockReturnValue({ max_fetched_at: daysAgo(10) }); // stale
     mockSeededCoursesAll.mockReturnValue([seededRow(course)]);
 
-    mockFetch
-      .mockResolvedValueOnce(mockTokenResponse())
-      .mockResolvedValueOnce(mockCoursePage([course]));
+    // Background refresh also starts here (finding 2), so use method-based dispatch:
+    // GET = token/lookup fetches, POST = course page fetches.
+    mockFetch.mockImplementation((_url: unknown, init?: { method?: string }) =>
+      Promise.resolve(init?.method === "POST" ? mockCoursePage([course]) : mockTokenResponse())
+    );
 
     const result = await fetchAllCourses({ kurstyp: 2, check1: true });
 
@@ -252,6 +256,51 @@ describe("stale-while-revalidate seed cache", () => {
     try {
       // Different filter keys → two separate doFetchAllCourses calls, but only one refresh
       await Promise.all([fetchAllCourses({ kurstyp: 1 }), fetchAllCourses({ kurstyp: 2 })]);
+
+      const startedCount = consoleSpy.mock.calls.filter(
+        (args) => args[0] === "[cache] Background course cache refresh started"
+      ).length;
+      expect(startedCount).toBe(1);
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  it("deletes stale courses from SQLite during background refresh (snapshot replacement)", async () => {
+    const course = makeMinimalCourse();
+    mockFetchedAtGet.mockReturnValue({ max_fetched_at: daysAgo(10) }); // stale
+    mockSeededCoursesAll.mockReturnValue([seededRow(course)]);
+
+    // Resolve when DELETE runs — proves the transaction performed snapshot replacement
+    let resolveDeleteCalled!: () => void;
+    const deleteCalled = new Promise<void>((resolve) => {
+      resolveDeleteCalled = resolve;
+    });
+    mockDeleteRun.mockImplementation(() => resolveDeleteCalled());
+
+    const freshCourse = makeMinimalCourse({ angebotId: 99 });
+    mockFetch.mockImplementation((_url: unknown, init?: { method?: string }) =>
+      Promise.resolve(init?.method === "POST" ? mockCoursePage([freshCourse]) : mockTokenResponse())
+    );
+
+    await fetchAllCourses({ kurstyp: 2 }); // returns stale data, triggers background refresh
+    await deleteCalled; // wait until the transaction's DELETE executes
+
+    expect(mockDeleteRun).toHaveBeenCalled();
+  });
+
+  it("triggers background refresh when check1=true and seed is stale", async () => {
+    const course = makeMinimalCourse({ hatFreiePlaetze: true });
+    mockFetchedAtGet.mockReturnValue({ max_fetched_at: daysAgo(10) }); // stale
+    mockSeededCoursesAll.mockReturnValue([seededRow(course)]);
+
+    mockFetch.mockImplementation((_url: unknown, init?: { method?: string }) =>
+      Promise.resolve(init?.method === "POST" ? mockCoursePage([course]) : mockTokenResponse())
+    );
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await fetchAllCourses({ kurstyp: 2, check1: true });
 
       const startedCount = consoleSpy.mock.calls.filter(
         (args) => args[0] === "[cache] Background course cache refresh started"

--- a/__tests__/staleSeedCache.test.ts
+++ b/__tests__/staleSeedCache.test.ts
@@ -1,23 +1,37 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // ── DB mock ───────────────────────────────────────────────────────────────────
-const { mockFetchedAtGet, mockSeededCoursesAll, mockInsertRun, mockDeleteRun, mockTransaction } =
-  vi.hoisted(() => ({
-    mockFetchedAtGet: vi.fn(),
-    mockSeededCoursesAll: vi.fn(),
-    mockInsertRun: vi.fn(),
-    mockDeleteRun: vi.fn(),
-    mockTransaction: vi.fn((fn: () => void) => fn),
-  }));
+const {
+  mockFetchedAtGet,
+  mockLookupFetchedAtGet,
+  mockLookupRowGet,
+  mockSeededCoursesAll,
+  mockInsertRun,
+  mockDeleteRun,
+  mockOrphanedImagesDeleteRun,
+  mockTransaction,
+} = vi.hoisted(() => ({
+  mockFetchedAtGet: vi.fn(),
+  mockLookupFetchedAtGet: vi.fn(),
+  mockLookupRowGet: vi.fn(),
+  mockSeededCoursesAll: vi.fn(),
+  mockInsertRun: vi.fn(),
+  mockDeleteRun: vi.fn(),
+  mockOrphanedImagesDeleteRun: vi.fn(),
+  mockTransaction: vi.fn((fn: () => void) => fn),
+}));
 
 vi.mock("@/lib/db", () => ({
   default: {
     prepare: vi.fn((sql: string) => {
       if (sql.includes("MAX(fetched_at)")) return { get: mockFetchedAtGet };
+      if (sql.includes("MIN(fetched_at)")) return { get: mockLookupFetchedAtGet };
+      if (sql.includes("FROM lookups WHERE type")) return { get: mockLookupRowGet };
       if (sql.includes("SELECT data") && sql.includes("kurstypId"))
         return { all: mockSeededCoursesAll };
       if (sql.includes("INSERT")) return { run: mockInsertRun };
       if (sql.includes("DELETE FROM courses")) return { run: mockDeleteRun };
+      if (sql.includes("DELETE FROM images")) return { run: mockOrphanedImagesDeleteRun };
       return { get: vi.fn().mockReturnValue(null), all: vi.fn().mockReturnValue([]), run: vi.fn() };
     }),
     transaction: mockTransaction,
@@ -29,7 +43,7 @@ const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
 // ── Module under test ─────────────────────────────────────────────────────────
-import { fetchAllCourses, _resetForTests } from "@/lib/sportPortal";
+import { fetchAllCourses, fetchLookups, _resetForTests } from "@/lib/sportPortal";
 import type { Course } from "@/lib/sportPortal";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -109,9 +123,12 @@ describe("stale-while-revalidate seed cache", () => {
   beforeEach(() => {
     _resetForTests();
     mockFetchedAtGet.mockReset();
+    mockLookupFetchedAtGet.mockReset();
+    mockLookupRowGet.mockReset();
     mockSeededCoursesAll.mockReset();
     mockInsertRun.mockReset();
     mockDeleteRun.mockReset();
+    mockOrphanedImagesDeleteRun.mockReset();
     mockFetch.mockReset();
     // Vitest sets NODE_ENV=test which disables the seeded cache; override for these tests.
     vi.stubEnv("NODE_ENV", "production");
@@ -309,5 +326,66 @@ describe("stale-while-revalidate seed cache", () => {
     } finally {
       consoleSpy.mockRestore();
     }
+  });
+
+  it("deletes orphaned image rows for courses removed from upstream API", async () => {
+    const course = makeMinimalCourse();
+    mockFetchedAtGet.mockReturnValue({ max_fetched_at: daysAgo(10) }); // stale
+    mockSeededCoursesAll.mockReturnValue([seededRow(course)]);
+
+    let resolveOrphanDeleteCalled!: () => void;
+    const orphanDeleteCalled = new Promise<void>((resolve) => {
+      resolveOrphanDeleteCalled = resolve;
+    });
+    mockOrphanedImagesDeleteRun.mockImplementation(() => resolveOrphanDeleteCalled());
+
+    const freshCourse = makeMinimalCourse({ angebotId: 99 });
+    mockFetch.mockImplementation((_url: unknown, init?: { method?: string }) =>
+      Promise.resolve(init?.method === "POST" ? mockCoursePage([freshCourse]) : mockTokenResponse())
+    );
+
+    await fetchAllCourses({ kurstyp: 2 });
+    await orphanDeleteCalled;
+
+    expect(mockOrphanedImagesDeleteRun).toHaveBeenCalled();
+  });
+});
+
+describe("seeded lookup cache", () => {
+  beforeEach(() => {
+    _resetForTests();
+    mockLookupFetchedAtGet.mockReset();
+    mockLookupRowGet.mockReset();
+    mockFetch.mockReset();
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("DISABLE_SEEDED_COURSE_CACHE", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("falls through to live API when lookup MIN(fetched_at) is stale even if courses are fresh", async () => {
+    mockFetchedAtGet.mockReturnValue({ max_fetched_at: daysAgo(1) }); // courses fresh
+    mockLookupFetchedAtGet.mockReturnValue({ min_fetched_at: daysAgo(10) }); // lookups stale
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true, data: [] }),
+    });
+
+    await fetchLookups();
+
+    expect(mockFetch).toHaveBeenCalled(); // lookup freshness check failed → live API
+  });
+
+  it("serves lookups from seed when all lookup types have fresh MIN(fetched_at)", async () => {
+    mockLookupFetchedAtGet.mockReturnValue({ min_fetched_at: daysAgo(1) }); // fresh
+    mockLookupRowGet.mockReturnValue({ data: "[]" }); // each type returns empty array
+
+    const result = await fetchLookups();
+
+    expect(mockFetch).not.toHaveBeenCalled(); // served from seed
+    expect(result).toBeDefined();
   });
 });

--- a/__tests__/staleSeedCache.test.ts
+++ b/__tests__/staleSeedCache.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ── DB mock ───────────────────────────────────────────────────────────────────
+const { mockFetchedAtGet, mockSeededCoursesAll, mockInsertRun, mockTransaction } = vi.hoisted(
+  () => ({
+    mockFetchedAtGet: vi.fn(),
+    mockSeededCoursesAll: vi.fn(),
+    mockInsertRun: vi.fn(),
+    mockTransaction: vi.fn((fn: () => void) => fn),
+  })
+);
+
+vi.mock("@/lib/db", () => ({
+  default: {
+    prepare: vi.fn((sql: string) => {
+      if (sql.includes("MAX(fetched_at)")) return { get: mockFetchedAtGet };
+      if (sql.includes("SELECT data") && sql.includes("kurstypId"))
+        return { all: mockSeededCoursesAll };
+      if (sql.includes("INSERT")) return { run: mockInsertRun };
+      return { get: vi.fn().mockReturnValue(null), all: vi.fn().mockReturnValue([]) };
+    }),
+    transaction: mockTransaction,
+  },
+}));
+
+// ── fetch mock ────────────────────────────────────────────────────────────────
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// ── Module under test ─────────────────────────────────────────────────────────
+import { fetchAllCourses, _resetForTests } from "@/lib/sportPortal";
+import type { Course } from "@/lib/sportPortal";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const now = () => Math.floor(Date.now() / 1000);
+const daysAgo = (d: number) => now() - d * 24 * 60 * 60;
+
+function makeMinimalCourse(overrides: Partial<Course> = {}): Course {
+  return {
+    angebotId: 1,
+    nummer: "TEST 1",
+    titel: "Test Course",
+    titelUrl: "Test_Course",
+    text: "",
+    kurstypId: 2,
+    aktivitaetId: 1,
+    ferientypId: 2,
+    ferienwocheId: 1,
+    schulkreisId: 1,
+    kategorieId: 1,
+    geschlechtId: 3,
+    jahrgangVon: 2014,
+    jahrgangBis: 2018,
+    von: "2026-07-13T10:00:00",
+    bis: "2026-07-17T16:00:00",
+    zeitpunkt1: "",
+    zeitpunkt2: "",
+    zeitpunkt3: "",
+    jahrgang: "",
+    geschlecht: "",
+    niveau: "",
+    kursOrt: "Test Venue",
+    hatFreiePlaetze: true,
+    hasBuchungscode: false,
+    status1: "",
+    anmeldeschluss: "0001-01-01T00:00:00",
+    lat: 47.38,
+    lng: 8.55,
+    approximate: false,
+    ...overrides,
+  };
+}
+
+function seededRow(course: Course) {
+  return {
+    data: JSON.stringify(course),
+    lat: course.lat ?? null,
+    lng: course.lng ?? null,
+    approximate: course.approximate ? 1 : 0,
+    source: "city-detail",
+  };
+}
+
+function mockTokenResponse() {
+  return {
+    ok: true,
+    headers: {
+      getSetCookie: () => ["XSRF-TOKEN=tok; Path=/", "__RequestVerificationToken=rvt; Path=/"],
+    },
+  };
+}
+
+function mockCoursePage(courses: Course[], total?: number) {
+  return {
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        success: true,
+        data: { total: total ?? courses.length, results: courses },
+      }),
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("stale-while-revalidate seed cache", () => {
+  beforeEach(() => {
+    _resetForTests();
+    mockFetchedAtGet.mockReset();
+    mockSeededCoursesAll.mockReset();
+    mockInsertRun.mockReset();
+    mockFetch.mockReset();
+    // Vitest sets NODE_ENV=test which disables the seeded cache; override for these tests.
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("DISABLE_SEEDED_COURSE_CACHE", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns seeded data immediately when seed is fresh", async () => {
+    const course = makeMinimalCourse();
+    mockFetchedAtGet.mockReturnValue({ max_fetched_at: daysAgo(1) }); // 1 day old — fresh
+    mockSeededCoursesAll.mockReturnValue([seededRow(course)]);
+
+    const result = await fetchAllCourses({ kurstyp: 2 });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].angebotId).toBe(1);
+    expect(mockFetch).not.toHaveBeenCalled(); // no upstream API calls
+  });
+
+  it("returns stale seeded data immediately without waiting for background refresh", async () => {
+    const course = makeMinimalCourse();
+    mockFetchedAtGet.mockReturnValue({ max_fetched_at: daysAgo(10) }); // 10 days old — stale
+    mockSeededCoursesAll.mockReturnValue([seededRow(course)]);
+
+    // Background refresh will call fetch — resolve it so the test doesn't hang
+    mockFetch
+      .mockResolvedValueOnce(mockTokenResponse()) // token
+      .mockResolvedValue(mockCoursePage([], 0)); // all course pages return empty
+
+    const result = await fetchAllCourses({ kurstyp: 2 });
+
+    // Stale data returned synchronously — doesn't wait for background fetch
+    expect(result).toHaveLength(1);
+    expect(result[0].angebotId).toBe(1);
+  });
+
+  it("triggers a background refresh when seed is stale", async () => {
+    const course = makeMinimalCourse();
+    mockFetchedAtGet.mockReturnValue({ max_fetched_at: daysAgo(10) });
+    mockSeededCoursesAll.mockReturnValue([seededRow(course)]);
+
+    const fetchCalled = new Promise<void>((resolve) => {
+      mockFetch.mockImplementation(() => {
+        resolve();
+        return Promise.resolve(mockTokenResponse());
+      });
+    });
+
+    await fetchAllCourses({ kurstyp: 2 });
+
+    // Background refresh should call fetch (for token at minimum)
+    await fetchCalled;
+    expect(mockFetch).toHaveBeenCalled();
+  });
+
+  it("does NOT trigger a background refresh when seed is fresh", async () => {
+    const course = makeMinimalCourse();
+    mockFetchedAtGet.mockReturnValue({ max_fetched_at: daysAgo(1) }); // fresh
+    mockSeededCoursesAll.mockReturnValue([seededRow(course)]);
+
+    await fetchAllCourses({ kurstyp: 2 });
+
+    // Allow any microtasks to settle
+    await Promise.resolve();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("falls through to live API when there is no seeded data", async () => {
+    mockFetchedAtGet.mockReturnValue(null); // no seed at all
+    mockSeededCoursesAll.mockReturnValue([]);
+
+    mockFetch
+      .mockResolvedValueOnce(mockTokenResponse())
+      .mockResolvedValueOnce(mockCoursePage([makeMinimalCourse()]));
+
+    const result = await fetchAllCourses({ kurstyp: 2 });
+
+    expect(result).toHaveLength(1);
+    expect(mockFetch).toHaveBeenCalled();
+  });
+
+  it("falls through to live API for check1=true when seed is stale", async () => {
+    const course = makeMinimalCourse({ hatFreiePlaetze: true });
+    mockFetchedAtGet.mockReturnValue({ max_fetched_at: daysAgo(10) }); // stale
+    mockSeededCoursesAll.mockReturnValue([seededRow(course)]);
+
+    mockFetch
+      .mockResolvedValueOnce(mockTokenResponse())
+      .mockResolvedValueOnce(mockCoursePage([course]));
+
+    const result = await fetchAllCourses({ kurstyp: 2, check1: true });
+
+    // check1 + stale seed → live API was called (not stale seeded data)
+    expect(mockFetch).toHaveBeenCalled();
+    expect(result).toHaveLength(1);
+  });
+
+  it("serves check1=true from seeded data when seed is fresh", async () => {
+    const course = makeMinimalCourse({ hatFreiePlaetze: true });
+    mockFetchedAtGet.mockReturnValue({ max_fetched_at: daysAgo(1) }); // fresh
+    mockSeededCoursesAll.mockReturnValue([seededRow(course)]);
+
+    const result = await fetchAllCourses({ kurstyp: 2, check1: true });
+
+    expect(result).toHaveLength(1);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("runs only one background refresh when two concurrent requests see stale seed (same key)", async () => {
+    const course = makeMinimalCourse();
+    mockFetchedAtGet.mockReturnValue({ max_fetched_at: daysAgo(10) });
+    mockSeededCoursesAll.mockReturnValue([seededRow(course)]);
+    mockFetch.mockResolvedValue(mockTokenResponse());
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      // Same filter key — coalesced via courseInFlight, only one doFetchAllCourses runs
+      await Promise.all([fetchAllCourses({ kurstyp: 2 }), fetchAllCourses({ kurstyp: 2 })]);
+
+      const startedCount = consoleSpy.mock.calls.filter(
+        (args) => args[0] === "[cache] Background course cache refresh started"
+      ).length;
+      expect(startedCount).toBe(1);
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  it("runs only one background refresh when two concurrent requests have different filter keys", async () => {
+    const course = makeMinimalCourse();
+    mockFetchedAtGet.mockReturnValue({ max_fetched_at: daysAgo(10) });
+    mockSeededCoursesAll.mockReturnValue([seededRow(course)]);
+    mockFetch.mockResolvedValue(mockTokenResponse());
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      // Different filter keys → two separate doFetchAllCourses calls, but only one refresh
+      await Promise.all([fetchAllCourses({ kurstyp: 1 }), fetchAllCourses({ kurstyp: 2 })]);
+
+      const startedCount = consoleSpy.mock.calls.filter(
+        (args) => args[0] === "[cache] Background course cache refresh started"
+      ).length;
+      expect(startedCount).toBe(1);
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+});

--- a/app/api/courses/route.ts
+++ b/app/api/courses/route.ts
@@ -140,19 +140,27 @@ export async function POST(req: NextRequest) {
     const enriched = courses
       .map((course) => {
         const venue = coords.get(course.kursOrt);
-        const lat = typeof course.lat === "number" ? course.lat : (venue?.lat ?? null);
-        const lng = typeof course.lng === "number" ? course.lng : (venue?.lng ?? null);
+        // Pre-baked coords (seeded LV95 or overrides) take precedence; fall back to geocoder.
+        const hasPrebakedCoords = typeof course.lat === "number" && typeof course.lng === "number";
+        const lat = hasPrebakedCoords ? course.lat : (venue?.lat ?? null);
+        const lng = hasPrebakedCoords ? course.lng : (venue?.lng ?? null);
+        // When coords come from geocoder (not pre-baked), use geocoder's approximate flag so
+        // that a precise swisstopo hit isn't overridden by a stale approximate=true in the DB.
+        const approximate = hasPrebakedCoords
+          ? (course.approximate ?? false)
+          : (venue?.approximate ?? false);
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { bild: _bild, ...rest } = course;
         return {
           ...rest,
           lat,
           lng,
-          approximate: course.approximate ?? venue?.approximate ?? false,
+          approximate,
         };
       })
       .filter((course) => {
-        if (!bounds || course.lat === null || course.lng === null) return true;
+        if (!bounds || typeof course.lat !== "number" || typeof course.lng !== "number")
+          return true;
         return (
           course.lat <= bounds.north &&
           course.lat >= bounds.south &&

--- a/lib/sportPortal.ts
+++ b/lib/sportPortal.ts
@@ -327,11 +327,19 @@ const getSeededLookupStmt = db.prepare<[string], { data: string }>(
   "SELECT data FROM lookups WHERE type = ?"
 );
 
+const getSeededLookupFetchedAtStmt = db.prepare<[], { min_fetched_at: number | null }>(
+  "SELECT MIN(fetched_at) AS min_fetched_at FROM lookups"
+);
+
 function fetchSeededLookups(): Record<LookupType, LookupOption[]> | null {
   if (!USE_SEEDED_CACHE()) return null;
 
-  const seedFetchedAt = getSeedFetchedAt();
-  if (!seedFetchedAt || Date.now() - seedFetchedAt * 1000 > SEEDED_CACHE_MAX_AGE_MS()) return null;
+  // Gate on MIN(lookups.fetched_at) independently of course freshness so a partial or
+  // complete lookup refresh failure doesn't silently serve stale filter options.
+  const lookupRow = getSeededLookupFetchedAtStmt.get();
+  const lookupFetchedAt = lookupRow?.min_fetched_at ?? null;
+  if (!lookupFetchedAt || Date.now() - lookupFetchedAt * 1000 > SEEDED_CACHE_MAX_AGE_MS())
+    return null;
 
   const entries = LOOKUP_TYPES.map((type) => {
     const row = getSeededLookupStmt.get(type);
@@ -402,6 +410,10 @@ const getAllCoursesCoordsStmt = db.prepare<
 >("SELECT angebotId, lat, lng, approximate, source FROM courses");
 
 const deleteAllCoursesStmt = db.prepare("DELETE FROM courses");
+
+const deleteOrphanedImagesStmt = db.prepare(
+  "DELETE FROM images WHERE angebotId NOT IN (SELECT angebotId FROM courses)"
+);
 
 const upsertRefreshedCourseStmt = db.prepare<
   [number, number, string, number | null, number | null, number, string | null, number, number]
@@ -730,6 +742,7 @@ async function runBackgroundRefresh(): Promise<void> {
           now
         );
       }
+      deleteOrphanedImagesStmt.run(); // match seed-import cleanup: remove images for dropped courses
     })();
 
     // 4. Reset in-memory caches so the next request reads fresh seeded data

--- a/lib/sportPortal.ts
+++ b/lib/sportPortal.ts
@@ -390,10 +390,18 @@ const courseInFlight = new Map<string, Promise<Course[]>>();
 const COURSES_TTL_MS = 5 * 60 * 1000;
 
 // Statements used by the background refresh to write fresh data back to SQLite
-const getExistingCourseCoordStmt = db.prepare<
-  [number],
-  { lat: number | null; lng: number | null; approximate: number; source: string | null }
->("SELECT lat, lng, approximate, source FROM courses WHERE angebotId = ?");
+const getAllCoursesCoordsStmt = db.prepare<
+  [],
+  {
+    angebotId: number;
+    lat: number | null;
+    lng: number | null;
+    approximate: number;
+    source: string | null;
+  }
+>("SELECT angebotId, lat, lng, approximate, source FROM courses");
+
+const deleteAllCoursesStmt = db.prepare("DELETE FROM courses");
 
 const upsertRefreshedCourseStmt = db.prepare<
   [number, number, string, number | null, number | null, number, string | null, number, number]
@@ -692,16 +700,22 @@ async function runBackgroundRefresh(): Promise<void> {
       return;
     }
 
-    // 3. Write to SQLite — preserve existing coords (LV95 from seed) where available;
-    //    new courses get null coords and will be geocoded on the next API request.
+    // 3. Write to SQLite — snapshot replacement so courses dropped by the upstream API
+    //    are removed rather than served indefinitely. Pre-read existing coords before the
+    //    transaction to preserve LV95 precision; new courses get null and are geocoded on
+    //    the next request.
+    const existingCoords = new Map(
+      getAllCoursesCoordsStmt.all().map((row) => [row.angebotId, row])
+    );
     const now = Math.floor(Date.now() / 1000);
     db.transaction(() => {
       for (const [type, data] of validLookups) {
         upsertRefreshedLookupStmt.run(type, JSON.stringify(data), now);
       }
+      deleteAllCoursesStmt.run(); // snapshot replacement — removes cancelled/expired courses
       for (let i = 0; i < allCourses.length; i++) {
         const course = allCourses[i];
-        const existing = getExistingCourseCoordStmt.get(course.angebotId);
+        const existing = existingCoords.get(course.angebotId);
         const { bild, ...courseData } = course;
         if (bild) upsertRefreshedImageStmt.run(course.angebotId, bild, now);
         upsertRefreshedCourseStmt.run(
@@ -747,6 +761,11 @@ async function doFetchAllCourses(filters: CourseFilters): Promise<Course[]> {
   if (seeded !== null) {
     if (isSeedStale()) startBackgroundRefresh();
     return seeded;
+  }
+  // Seed exists but was bypassed (stale + check1) — still revalidate so future requests
+  // benefit from a fresh seed, including check1 requests once the seed is warm again.
+  if (USE_SEEDED_CACHE() && getSeedFetchedAt() && isSeedStale()) {
+    startBackgroundRefresh();
   }
   return fetchCoursesFromApi(filters);
 }

--- a/lib/sportPortal.ts
+++ b/lib/sportPortal.ts
@@ -389,6 +389,26 @@ const courseCache = new Map<string, CourseCacheEntry>();
 const courseInFlight = new Map<string, Promise<Course[]>>();
 const COURSES_TTL_MS = 5 * 60 * 1000;
 
+// Statements used by the background refresh to write fresh data back to SQLite
+const getExistingCourseCoordStmt = db.prepare<
+  [number],
+  { lat: number | null; lng: number | null; approximate: number; source: string | null }
+>("SELECT lat, lng, approximate, source FROM courses WHERE angebotId = ?");
+
+const upsertRefreshedCourseStmt = db.prepare<
+  [number, number, string, number | null, number | null, number, string | null, number, number]
+>(`INSERT OR REPLACE INTO courses
+    (angebotId, kurstypId, data, lat, lng, approximate, source, order_index, fetched_at)
+   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`);
+
+const upsertRefreshedLookupStmt = db.prepare<[string, string, number]>(
+  "INSERT OR REPLACE INTO lookups (type, data, fetched_at) VALUES (?, ?, ?)"
+);
+
+const upsertRefreshedImageStmt = db.prepare<[number, string, number]>(
+  "INSERT OR REPLACE INTO images (angebotId, bild, fetched_at) VALUES (?, ?, ?)"
+);
+
 const getSeededCoursesStmt = db.prepare<
   [number],
   {
@@ -405,13 +425,18 @@ const getSeededCoursesStmt = db.prepare<
 const getSeededFetchedAtStmt = db.prepare<[], { max_fetched_at: number | null }>(
   "SELECT MAX(fetched_at) AS max_fetched_at FROM courses"
 );
-// Cached once per process: the seed's build timestamp never changes at runtime.
+// Cached per process; reset to undefined by the background refresh after a successful DB write.
 let cachedSeedFetchedAt: number | null | undefined = undefined;
 function getSeedFetchedAt(): number | null {
   if (cachedSeedFetchedAt !== undefined) return cachedSeedFetchedAt;
   const row = getSeededFetchedAtStmt.get();
   cachedSeedFetchedAt = row?.max_fetched_at ?? null;
   return cachedSeedFetchedAt;
+}
+
+function isSeedStale(): boolean {
+  const seedFetchedAt = getSeedFetchedAt();
+  return !seedFetchedAt || Date.now() - seedFetchedAt * 1000 > SEEDED_CACHE_MAX_AGE_MS();
 }
 
 function pruneCourseCache() {
@@ -525,12 +550,13 @@ function matchesFilters(course: Course, filters: CourseFilters): boolean {
 
 function fetchSeededCourses(filters: CourseFilters): Course[] | null {
   if (!USE_SEEDED_CACHE()) return null;
-  // check1 filters by live availability (hatFreiePlaetze) which changes continuously;
-  // seeded values are stale so we must fall through to the upstream API.
-  if (filters.check1) return null;
 
   const seedFetchedAt = getSeedFetchedAt();
-  if (!seedFetchedAt || Date.now() - seedFetchedAt * 1000 > SEEDED_CACHE_MAX_AGE_MS()) return null;
+  if (!seedFetchedAt) return null; // no seeded data at all
+
+  // check1 (only-available filter) is only reliable on fresh data — hatFreiePlaetze changes
+  // in real time so stale seeded values must not be used; fall through to the upstream API.
+  if (filters.check1 && isSeedStale()) return null;
 
   const rows = getSeededCoursesStmt.all(filters.kurstyp ?? 2);
   if (rows.length === 0) return null;
@@ -546,10 +572,7 @@ function fetchSeededCourses(filters: CourseFilters): Course[] | null {
     .filter((course) => matchesFilters(course, filters));
 }
 
-async function doFetchAllCourses(filters: CourseFilters): Promise<Course[]> {
-  const seeded = fetchSeededCourses(filters);
-  if (seeded) return seeded;
-
+async function fetchCoursesFromApi(filters: CourseFilters): Promise<Course[]> {
   const { xsrfToken, requestVerificationToken } = await getTokens();
 
   const cookieHeader = `__RequestVerificationToken=${requestVerificationToken}; XSRF-TOKEN=${xsrfToken}`;
@@ -629,6 +652,105 @@ async function doFetchAllCourses(filters: CourseFilters): Promise<Course[]> {
   return allCourses;
 }
 
+// ── Background stale-while-revalidate refresh ────────────────────────────────
+
+let backgroundRefreshInFlight = false;
+
+async function runBackgroundRefresh(): Promise<void> {
+  console.log("[cache] Background course cache refresh started");
+  const t0 = Date.now();
+
+  try {
+    // 1. Refresh lookups
+    const lookupEntries = await Promise.allSettled(
+      LOOKUP_TYPES.map(async (type) => {
+        const res = await fetchWithRetry(`${BASE_URL}/API/api/lookups/init/${type}`, {}, "lookups");
+        const json = await res.json();
+        const parsed = parseJsonObject(json, "lookups");
+        if (parsed.success !== true || !Array.isArray(parsed.data)) return null;
+        return [type, parsed.data] as [LookupType, LookupOption[]];
+      })
+    );
+    const validLookups = lookupEntries
+      .filter(
+        (r): r is PromiseFulfilledResult<[LookupType, LookupOption[]]> =>
+          r.status === "fulfilled" && r.value !== null
+      )
+      .map((r) => r.value);
+
+    // 2. Fetch all courses for each kurstyp (no filters — refresh the full seed).
+    //    Abort if any kurstyp fails: a partial write would update MAX(fetched_at) and
+    //    make isSeedStale() return false even though some kurstypId rows are still old.
+    const allCourses: Course[] = [];
+    for (const kurstyp of [1, 2] as const) {
+      const courses = await fetchCoursesFromApi({ kurstyp });
+      allCourses.push(...courses);
+    }
+
+    if (allCourses.length === 0) {
+      console.warn("[cache] Background refresh fetched 0 courses, aborting");
+      return;
+    }
+
+    // 3. Write to SQLite — preserve existing coords (LV95 from seed) where available;
+    //    new courses get null coords and will be geocoded on the next API request.
+    const now = Math.floor(Date.now() / 1000);
+    db.transaction(() => {
+      for (const [type, data] of validLookups) {
+        upsertRefreshedLookupStmt.run(type, JSON.stringify(data), now);
+      }
+      for (let i = 0; i < allCourses.length; i++) {
+        const course = allCourses[i];
+        const existing = getExistingCourseCoordStmt.get(course.angebotId);
+        const { bild, ...courseData } = course;
+        if (bild) upsertRefreshedImageStmt.run(course.angebotId, bild, now);
+        upsertRefreshedCourseStmt.run(
+          course.angebotId,
+          course.kurstypId,
+          JSON.stringify(courseData),
+          existing?.lat ?? null,
+          existing?.lng ?? null,
+          existing?.approximate ?? 1,
+          existing?.source ?? null,
+          i,
+          now
+        );
+      }
+    })();
+
+    // 4. Reset in-memory caches so the next request reads fresh seeded data
+    cachedSeedFetchedAt = undefined;
+    courseCache.clear();
+    if (validLookups.length > 0) {
+      lookupsCache = null;
+      lookupsFetchedAt = 0;
+    }
+
+    console.log(
+      `[cache] Background refresh complete in ${Date.now() - t0}ms: ${allCourses.length} courses`
+    );
+  } catch (err) {
+    console.error("[cache] Background refresh failed:", err);
+  } finally {
+    backgroundRefreshInFlight = false;
+  }
+}
+
+function startBackgroundRefresh(): void {
+  if (backgroundRefreshInFlight) return;
+  backgroundRefreshInFlight = true;
+  void runBackgroundRefresh();
+}
+
+async function doFetchAllCourses(filters: CourseFilters): Promise<Course[]> {
+  const seeded = fetchSeededCourses(filters);
+  if (seeded !== null) {
+    if (isSeedStale()) startBackgroundRefresh();
+    return seeded;
+  }
+  return fetchCoursesFromApi(filters);
+}
+
 export async function fetchAllCourses(filters: CourseFilters): Promise<Course[]> {
   const key = cacheKey(filters);
 
@@ -657,4 +779,14 @@ export async function fetchAllCourses(filters: CourseFilters): Promise<Course[]>
 
   courseInFlight.set(key, promise);
   return promise;
+}
+
+export function _resetForTests(): void {
+  tokenCache = null;
+  lookupsCache = null;
+  lookupsFetchedAt = 0;
+  courseCache.clear();
+  courseInFlight.clear();
+  cachedSeedFetchedAt = undefined;
+  backgroundRefreshInFlight = false;
 }

--- a/lib/sportPortal.ts
+++ b/lib/sportPortal.ts
@@ -699,17 +699,18 @@ async function runBackgroundRefresh(): Promise<void> {
       .map((r) => r.value);
 
     // 2. Fetch all courses for each kurstyp (no filters — refresh the full seed).
-    //    Abort if any kurstyp fails: a partial write would update MAX(fetched_at) and
-    //    make isSeedStale() return false even though some kurstypId rows are still old.
+    //    Abort if any kurstyp fails OR returns 0 courses: a partial write would update
+    //    MAX(fetched_at) and make isSeedStale() return false even though some kurstypId
+    //    rows are still old. An empty-but-successful response is treated as a transient
+    //    fault because both types are always populated in production.
     const allCourses: Course[] = [];
     for (const kurstyp of [1, 2] as const) {
       const courses = await fetchCoursesFromApi({ kurstyp });
+      if (courses.length === 0) {
+        console.warn(`[cache] Background refresh: kurstyp ${kurstyp} returned 0 courses, aborting`);
+        return;
+      }
       allCourses.push(...courses);
-    }
-
-    if (allCourses.length === 0) {
-      console.warn("[cache] Background refresh fetched 0 courses, aborting");
-      return;
     }
 
     // 3. Write to SQLite — snapshot replacement so courses dropped by the upstream API


### PR DESCRIPTION
## Summary

- Seeded SQLite course cache now uses stale-while-revalidate: stale data is served immediately while a background refresh runs in the background, eliminating the ~42 s live-API fallback on cache expiry
- Background refresh fetches all courses for kurstyp 1 and 2, aborts entirely if either fails (prevents partial writes that would reset `fetched_at` for only one kurstyp), and preserves existing LV95 coordinates for known venues
- `check1=true` (available spots only) always hits the live API when the seed is stale, since availability changes in real time; serves from seed when fresh
- Fixed `approximate` flag logic in `app/api/courses/route.ts`: use geocoder's `approximate` value when coords come from the geocoder (not pre-baked), so a precise swisstopo hit is never overridden by a stale `approximate=true` in the DB
- Added 9 Vitest tests covering fresh/stale seed paths, background refresh dedup, check1 behaviour, and concurrent request coalescing

## Test plan

- [ ] Run `npm test` — all tests pass including new `staleSeedCache.test.ts`
- [ ] Run `npm run typecheck && npm run lint && npm run format:check`
- [ ] Deploy to staging: first request after seed expires returns immediately (stale data), background refresh completes in background, subsequent requests serve fresh data

🤖 Generated with [Claude Code](https://claude.com/claude-code)